### PR TITLE
Fix UI issues in breakdown, dashboard, and NaiveProxy forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to RouteBox are documented here.
 
 ## [Unreleased]
 
+### Fixes
+
+- **Breakdown range switcher no longer clips "Month"** (#3) — the Live/1h/3h/24h/Week/Month pills
+  now size to their labels instead of six equal truncating columns.
+- **Breakdown domain drill-down got a back button** (#3) — a slim "Back to all domains" /
+  "Back to {domain}" row at the top of the By Domain panel steps back one level, instead of
+  relying on the filter chip or re-clicking the active row.
+- **Chain badges are no longer bold in "Group by chain"** (#3) — the chip style now pins its own
+  font weight, so badges look the same everywhere.
+- **Dashboard "Managed by systemd (unit)" spacing** (#3) — the unit name no longer glues to the
+  word "systemd".
+- **NaiveProxy "Import from link" is a proper button** (#3) — it now matches the dashed import
+  button used by the VLESS / Trojan / Hysteria2 / Shadowsocks forms instead of a bare text link.
+
 ## [0.21.1] - 2026-06-26
 
 ### Fixes

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -377,6 +377,9 @@ code, pre, .font-mono {
 	align-items: center;
 	padding: 0.125rem 0.5rem;
 	font-size: 0.75rem;
+	/* Explicit weight so chips look the same everywhere, even inside
+	   font-medium wrappers (e.g. group-by-chain header cards) */
+	font-weight: 400;
 	border-radius: 0.25rem;
 	background-color: color-mix(in srgb, var(--ctp-primary) 20%, transparent);
 	color: var(--ctp-primary);

--- a/frontend/src/lib/components/config/outbound/NaiveForm.svelte
+++ b/frontend/src/lib/components/config/outbound/NaiveForm.svelte
@@ -56,8 +56,11 @@
 		<button
 			type="button"
 			onclick={onImport}
-			class="text-sm text-[var(--ctp-primary)] hover:underline"
+			class="w-full px-4 py-2 bg-[var(--ctp-surface0)] border border-dashed border-[var(--ctp-surface2)] rounded-lg text-[var(--ctp-subtext1)] hover:border-[var(--ctp-primary)] hover:text-[var(--ctp-primary)] transition-colors flex items-center justify-center gap-2"
 		>
+			<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+			</svg>
 			{$t('outbounds.importFromNaive')}
 		</button>
 	{/if}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -1207,6 +1207,8 @@
     "showAll": "Show all",
     "showLess": "Show less",
     "rangeLive": "Live",
+    "backToDomains": "Back to all domains",
+    "backToApex": "Back to {domain}",
     "clientsLabel": "clients",
     "domainsLabel": "domains",
     "chainsLabel": "chains",

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -405,7 +405,7 @@
 				<div class="min-w-0 flex flex-col sm:flex-row sm:items-baseline sm:gap-1.5">
 					<span class="text-[10px] uppercase tracking-wide text-[var(--ctp-overlay1)] flex-shrink-0">Managed by</span>
 					{#if status.managed_by === 'systemd'}
-						<span class="text-sm text-[var(--ctp-primary)] truncate">systemd{#if status.service_name} <span class="text-[10px] text-[var(--ctp-overlay0)]">({status.service_name})</span>{/if}</span>
+						<span class="text-sm text-[var(--ctp-primary)] truncate">systemd{#if status.service_name}<span class="ml-1 text-[10px] text-[var(--ctp-overlay0)]">({status.service_name})</span>{/if}</span>
 					{:else}
 						<span class="text-sm text-[var(--ctp-text)]">standalone</span>
 					{/if}

--- a/frontend/src/routes/monitor/breakdown/+page.svelte
+++ b/frontend/src/routes/monitor/breakdown/+page.svelte
@@ -524,11 +524,11 @@ import { PRESETS as VOLUME_PRESETS, bytesFromUnit, splitBytes, type VolumeUnit }
 			</div>
 		</div>
 		<div class="hidden sm:block flex-1"></div>
-		<div class="grid grid-cols-6 gap-0.5 bg-[var(--ctp-mantle)] rounded-md p-0.5 self-start sm:self-auto">
+		<div class="flex gap-0.5 bg-[var(--ctp-mantle)] rounded-md p-0.5 self-start sm:self-auto">
 			{#each [{m:'live',l:$t('breakdown.rangeLive')},{m:'1h',l:'1h'},{m:'3h',l:'3h'},{m:'24h',l:'24h'},{m:'week',l:'Week'},{m:'month',l:'Month'}] as r}
 				<button
 					onclick={() => viewMode = r.m as ViewMode}
-					class="px-1.5 py-1 text-xs text-center rounded truncate transition-colors {viewMode === r.m
+					class="px-1.5 py-1 text-xs text-center rounded whitespace-nowrap transition-colors {viewMode === r.m
 						? 'bg-[var(--ctp-surface2)] text-[var(--ctp-text)]'
 						: 'text-[var(--ctp-overlay1)] hover:text-[var(--ctp-text)]'}"
 				>{r.l}</button>
@@ -595,6 +595,18 @@ import { PRESETS as VOLUME_PRESETS, bytesFromUnit, splitBytes, type VolumeUnit }
 			<h2 class="text-sm font-semibold text-[var(--ctp-subtext1)] uppercase tracking-wide">{title}</h2>
 			<span class="text-xs text-[var(--ctp-overlay0)]">{buckets.length}</span>
 		</div>
+		{#if dim === 'domain' && filters.domain !== null}
+			{@const apex = apexDomain(filters.domain)}
+			<button
+				onclick={domainBack}
+				class="w-full flex items-center gap-1.5 px-4 py-1.5 text-xs text-[var(--ctp-overlay1)] hover:text-[var(--ctp-primary)] hover:bg-[var(--ctp-surface1)] transition-colors border-b border-[var(--ctp-surface2)]"
+			>
+				<svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+				</svg>
+				<span class="truncate">{filters.domain === apex ? $t('breakdown.backToDomains') : $t('breakdown.backToApex', { values: { domain: apex } })}</span>
+			</button>
+		{/if}
 		{#if buckets.length > 0}
 			<div class="px-4 py-3 border-b border-[var(--ctp-surface2)]">
 				<PieChart


### PR DESCRIPTION
This PR addresses several UI/UX issues across the application:

## Summary
Fixes layout and styling issues in the breakdown monitor, dashboard status display, and NaiveProxy import form, plus adds a domain drill-down navigation feature.

## Key Changes

- **Breakdown range switcher** — Changed from fixed 6-column grid to flexible layout so button labels don't get truncated (fixes "Month" being clipped)
- **Breakdown domain drill-down** — Added a back button at the top of the By Domain panel to navigate back to parent domain or all domains, with i18n support for both states
- **Chain badges styling** — Explicitly set `font-weight: 400` on badge elements so they maintain consistent appearance even when nested in `font-medium` containers (e.g., group-by-chain headers)
- **Dashboard systemd spacing** — Added margin between "systemd" text and the service unit name in parentheses to prevent them from appearing glued together
- **NaiveProxy import button** — Converted from plain text link to a proper dashed button matching the style of other import buttons in the form, with an upload icon

## Implementation Details

- Range switcher: Changed `grid grid-cols-6` to `flex` with `gap-0.5`, and replaced `truncate` with `whitespace-nowrap` on buttons
- Domain back button: Conditionally rendered when in domain view with active filter, uses `apexDomain()` utility to determine navigation text
- Badge styling: Added CSS comment explaining the explicit font-weight override
- Systemd spacing: Added `ml-1` margin class to the service name span
- NaiveProxy button: Applied full-width button styling with dashed border, hover states, and SVG upload icon

https://claude.ai/code/session_01NbdEmWjek5CrABTMXc43H8