### PR TITLE
fix(awg): decommission the outgoing backend on switch + boot-time residue reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to RouteBox are documented here.
 
 ## [Unreleased]
 
+### Fixes
+
+- **Switching the AWG backend now actually decommissions the kernel runtime.** The
+  kernel→singbox switch used to only check "server disabled" and flip the setting — an
+  enabled-but-inactive `awg-quick@` unit, a manually-launched interface (`awg-quick up`
+  outside the unit), or a broken `awg` tool all passed that check while the kernel tunnel
+  stayed (or came back at next boot) alive, invisible to the panel and competing with the
+  singbox endpoint for the UDP port. The switch now tears the old backend down first:
+  `systemctl disable --now awg-quick@<iface>` (clears boot persistence), then `awg-quick
+  down` for manually-launched interfaces, then `ip link delete` + explicit RBOX-AWG-*
+  chain cleanup as a last resort — success is judged by the interface actually being gone,
+  not by any one command's exit code. The reverse (singbox→kernel) switch likewise drops an
+  orphaned managed endpoint from the active config.
+- **Boot-time backend residue reconcile.** Installs already in the split state (settings say
+  `singbox`, `awg-quick@` still enabled/running — or settings say `kernel` with a leftover
+  managed endpoint in the config) are healed at RouteBox startup. Only interfaces RouteBox
+  ever rendered a conf for are touched, so an operator's unrelated awg-quick setup is safe.
+- **Kernel AWG Disable handles every launch variant** — non-systemd boxes and manually
+  launched interfaces are now taken down too (previously only the systemd unit was stopped,
+  and Disable reported success while the interface kept running).
+- **Backend switch resets a stale `awg.enabled=true`** so a later RouteBox restart cannot
+  rehydrate the newly selected backend as silently enabled.
+
 ## [0.24.1] - 2026-07-20
 
 ### Fixes

--- a/backend/cmd/routebox/main.go
+++ b/backend/cmd/routebox/main.go
@@ -402,6 +402,11 @@ func main() {
 	} else {
 		awgMgr.Rehydrate(context.Background(), awgDesired())
 	}
+	// Heal leftovers of the INACTIVE backend: a switch on an older build (or a
+	// crash mid-switch) can leave awg-quick@<iface> enabled/running while the
+	// backend is singbox — a live, panel-invisible kernel tunnel — or an orphaned
+	// managed endpoint in the active config while the backend is kernel.
+	awgMgr.ReconcileBackendResidue(context.Background())
 	apiHandler.SetAWG(awgMgr)
 
 	// AWG expiry sweep — tied to AWG's lifecycle, NOT the vps-only mode gate.

--- a/backend/internal/api/awg_handlers_test.go
+++ b/backend/internal/api/awg_handlers_test.go
@@ -474,6 +474,72 @@ func TestBackendSwitchRejectedWhileEnableInFlight(t *testing.T) {
 		t.Fatal("rejected switch must not persist awg.backend")
 	}
 }
+// awgRecordingRunner records every argv (thread-safe not needed: handler path is
+// synchronous) and answers everything with ("", nil).
+type awgRecordingRunner struct{ calls [][]string }
+
+func (r *awgRecordingRunner) Run(_ context.Context, name string, args ...string) (string, string, error) {
+	r.calls = append(r.calls, append([]string{name}, args...))
+	return "", "", nil
+}
+
+func (r *awgRecordingRunner) saw(sub string) bool {
+	for _, c := range r.calls {
+		if strings.Contains(strings.Join(c, " "), sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// A validated kernel->singbox switch must (1) decommission the kernel runtime —
+// at minimum clear awg-quick@'s boot persistence, which the Enabled==false guard
+// alone never did (the reported bug: kernel kept running after the switch),
+// (2) persist the new backend, (3) reset a stale-true awg.enabled so a restart
+// can't rehydrate the NEW backend as silently enabled, and (4) mirror the switch
+// onto the live Manager.
+func TestBackendSwitchDecommissionsKernel(t *testing.T) {
+	dir := t.TempDir()
+	awgDir := filepath.Join(dir, "amneziawg")
+	if err := os.MkdirAll(awgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	run := &awgRecordingRunner{}
+	m := awg.NewManagerForTest(run, awgDir, serverPriv, awg.Config{
+		Iface: "awg-rb0", Subnet: "10.10.0.0/24", ServerIP: "10.10.0.1",
+		ListenPort: 51820, MTU: 1420, DNS: []string{"1.1.1.1"},
+	})
+	m.SetBackend("kernel")
+	sm := newAWGSettings(t, dir, "")
+	// Stale persisted state: backend kernel, enabled=true, but the live probe sees
+	// no iface (e.g. `awg` tool broken after a restart) — the guard passes.
+	if err := sm.Update(map[string]interface{}{"awg.backend": "kernel", "awg.enabled": true}); err != nil {
+		t.Fatal(err)
+	}
+	h := &Handler{settings: sm}
+	h.SetAWG(m)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/settings", strings.NewReader(`{"awg.backend":"singbox"}`))
+	h.UpdateSettings(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("switch = %d; want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if !run.saw("systemctl disable --now awg-quick@awg-rb0") {
+		t.Fatalf("switch must decommission the kernel unit; calls=%v", run.calls)
+	}
+	got := sm.Get().Awg
+	if got.Backend != "singbox" {
+		t.Fatalf("backend not persisted: %q", got.Backend)
+	}
+	if got.Enabled {
+		t.Fatal("switch must reset the stale awg.enabled flag")
+	}
+	if m.BackendName() != "singbox" {
+		t.Fatalf("live Manager backend = %q; want singbox", m.BackendName())
+	}
+}
+
 // orchestrator input — the panel's Save is the single writer; Enable ignores body.
 func TestAwgEnableInputFromSettings(t *testing.T) {
 	in := awgEnableInput(settings.AwgSettings{

--- a/backend/internal/api/settings_handlers.go
+++ b/backend/internal/api/settings_handlers.go
@@ -114,6 +114,25 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusConflict, "apply or discard pending config changes before switching backend")
 			return
 		}
+		// Decommission the OUTGOING backend BEFORE the setting is persisted. The
+		// Enabled==false guard above is necessary but not sufficient: an
+		// enabled-but-inactive awg-quick unit, a manually-launched iface, or a
+		// broken `awg` tool all pass it while the kernel tunnel is (or will be at
+		// next boot) alive — and after the switch Status routes to the new
+		// backend, so the leftover keeps running panel-invisibly. Failing here
+		// leaves settings AND Manager.backend unchanged (no split state).
+		if h.awg != nil {
+			if err := h.awg.PrepareBackendSwitch(r.Context(), bs); err != nil {
+				writeError(w, http.StatusConflict, "failed to decommission the previous backend: "+err.Error())
+				return
+			}
+		}
+		// The switch requires a disabled server, but the PERSISTED awg.enabled can
+		// still be stale-true (e.g. kernel was enabled, RouteBox restarted, and the
+		// live-iface probe failed). Left as-is, the next restart would rehydrate
+		// the NEW backend as enabled and silently start serving. Persist false
+		// atomically with the backend value.
+		updates["awg.enabled"] = false
 	}
 
 	// Apply updates

--- a/backend/internal/awg/iface.go
+++ b/backend/internal/awg/iface.go
@@ -24,10 +24,76 @@ func (m *Manager) iface_Up(ctx context.Context) error {
 	return err
 }
 
-// iface_Down stops+disables the interface (PostDown reverts NAT).
+// iface_Down stops the interface AND clears its boot persistence, covering every
+// launch variant — not just the systemd unit:
+//   - `systemctl disable --now` handles the unit-managed case and removes the
+//     enable symlink (an enabled-but-inactive unit would resurrect the kernel
+//     iface at the next boot);
+//   - a manually-launched iface (`awg-quick up` outside the unit) is untouched by
+//     the unit stop, so if the link is still present we run `awg-quick down`
+//     directly (its PostDown reverts NAT);
+//   - with awg-tools broken/missing (or no systemd at all), the last resort is
+//     `ip link delete` plus an explicit RBOX-AWG-* chain teardown, because
+//     PostDown never ran on that path.
+//
+// Success is judged by the OUTCOME (link gone), not by any one command's exit
+// code — `systemctl` legitimately fails on non-systemd boxes.
 func (m *Manager) iface_Down(ctx context.Context) error {
-	_, _, err := m.run.Run(ctx, "systemctl", "disable", "--now", "awg-quick@"+m.iface)
-	return err
+	_, _, sysErr := m.run.Run(ctx, "systemctl", "disable", "--now", "awg-quick@"+m.iface)
+	if !m.kernelIfacePresent(ctx) {
+		return nil
+	}
+	if _, _, err := m.run.Run(ctx, "awg-quick", "down", m.iface); err == nil && !m.kernelIfacePresent(ctx) {
+		return nil
+	}
+	_, _, _ = m.run.Run(ctx, "ip", "link", "delete", "dev", m.iface)
+	m.cleanupNATChains(ctx)
+	if m.kernelIfacePresent(ctx) {
+		if sysErr != nil {
+			return fmt.Errorf("interface %s is still up after teardown (systemctl: %v)", m.iface, sysErr)
+		}
+		return fmt.Errorf("interface %s is still up after teardown", m.iface)
+	}
+	return nil
+}
+
+// kernelIfacePresent reports whether the kernel netdev exists, independent of the
+// awg tool (which may be broken/uninstalled while the module keeps the iface
+// alive). `ip link show dev <iface>` exits non-zero when the device is absent and
+// names it in stdout when present; both are required so a permissive fake runner
+// ("" output, nil error) reads as absent.
+func (m *Manager) kernelIfacePresent(ctx context.Context) bool {
+	out, _, err := m.run.Run(ctx, "ip", "link", "show", "dev", m.iface)
+	return err == nil && strings.Contains(out, m.iface)
+}
+
+// kernelUnitEnabled reports whether awg-quick@<iface> is systemd-enabled (boot
+// persistence). Degrades to false where systemctl is absent or the unit unknown.
+func (m *Manager) kernelUnitEnabled(ctx context.Context) bool {
+	out, _, err := m.run.Run(ctx, "systemctl", "is-enabled", "awg-quick@"+m.iface)
+	return err == nil && strings.TrimSpace(out) == "enabled"
+}
+
+// cleanupNATChains reverts the RBOX-AWG-* chains exactly like the rendered
+// PostDown (unlink/flush/delete per chain), for teardown paths where awg-quick
+// never ran PostDown. Every step tolerates absence; errors are ignored.
+func (m *Manager) cleanupNATChains(ctx context.Context) {
+	for _, ch := range []struct {
+		table   []string
+		builtin string
+		chain   string
+	}{
+		{[]string{"-t", "nat"}, "POSTROUTING", "RBOX-AWG-NAT"},
+		{nil, "FORWARD", "RBOX-AWG-FWD"},
+		{nil, "INPUT", "RBOX-AWG-IN"},
+	} {
+		unlink := append(append([]string{}, ch.table...), "-D", ch.builtin, "-j", ch.chain)
+		flush := append(append([]string{}, ch.table...), "-F", ch.chain)
+		del := append(append([]string{}, ch.table...), "-X", ch.chain)
+		_, _, _ = m.run.Run(ctx, "iptables", unlink...)
+		_, _, _ = m.run.Run(ctx, "iptables", flush...)
+		_, _, _ = m.run.Run(ctx, "iptables", del...)
+	}
 }
 
 // iface_SyncConf reloads peers live: `awg-quick strip` -> 0600 temp file ->

--- a/backend/internal/awg/singbox.go
+++ b/backend/internal/awg/singbox.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/netip"
+	"os"
 	"strings"
 
 	"routebox/backend/internal/awg/cps"
@@ -39,6 +40,85 @@ func (m *Manager) BackendName() string {
 		return "singbox"
 	}
 	return "kernel"
+}
+
+// PrepareBackendSwitch decommissions the OUTGOING backend's runtime before a
+// validated backend switch is persisted. The handler's Enabled==false guard is
+// not enough: an enabled-but-inactive awg-quick unit, a manually-launched iface
+// (`awg-quick up` outside the unit), or a broken `awg` tool all read as
+// "disabled" while the kernel tunnel is (or will be, at next boot) alive — and
+// once Status routes to the new backend, that leftover is panel-invisible and
+// competes with the singbox endpoint for the UDP listen port. Idempotent; a
+// same-backend call is a no-op.
+func (m *Manager) PrepareBackendSwitch(ctx context.Context, target string) error {
+	if m.BackendName() == target {
+		return nil
+	}
+	switch target {
+	case "singbox":
+		// kernel -> singbox: stop the iface (whatever launched it) and clear the
+		// unit's boot persistence.
+		return m.iface_Down(ctx)
+	case "kernel":
+		// singbox -> kernel: drop the managed endpoint from the active config so a
+		// disable that failed mid-way (or hand-edited settings) can't leave the
+		// fork serving AWG alongside the kernel iface.
+		return m.decommissionSingbox()
+	}
+	return fmt.Errorf("invalid backend %q", target)
+}
+
+// decommissionSingbox removes the managed AWG endpoint from the ACTIVE sing-box
+// config (reloading only on a real change). Shared by disableSingbox, the
+// singbox->kernel switch, and the boot-time residue reconcile. A nil cfgSync
+// (not wired yet) is a no-op, not an error.
+func (m *Manager) decommissionSingbox() error {
+	m.mu.Lock()
+	s, apply := m.cfgSync, m.applyFn
+	m.mu.Unlock()
+	if s == nil {
+		return nil
+	}
+	changed, err := s.SyncAwgEndpointActive(config.ManagedAwgServerTag, nil)
+	if err != nil {
+		return err
+	}
+	if changed && apply != nil {
+		return apply()
+	}
+	return nil
+}
+
+// ReconcileBackendResidue heals leftovers of the INACTIVE backend at boot. The
+// switch path (PrepareBackendSwitch) protects new switches, but installs that
+// switched on older builds — or crashed mid-switch — can already be in the split
+// state: settings say "singbox" while awg-quick@<iface> is still enabled/running
+// (the reported bug: the kernel backend kept working after the switch), or say
+// "kernel" while an orphaned managed endpoint sits in the active config.
+// Best-effort: failures are logged, never fatal to boot.
+func (m *Manager) ReconcileBackendResidue(ctx context.Context) {
+	if m.backendIs("singbox") {
+		// Only touch the kernel unit/iface when RouteBox ever rendered its conf —
+		// the conf file marks the iface name as ours, so an operator's unrelated
+		// awg-quick setup is never torn down.
+		if _, err := os.Stat(m.confPath); err != nil {
+			return
+		}
+		unitEnabled := m.kernelUnitEnabled(ctx)
+		ifacePresent := m.kernelIfacePresent(ctx)
+		if !unitEnabled && !ifacePresent {
+			return
+		}
+		log.Printf("awg: backend is singbox but the kernel runtime is still around (unit enabled=%v, iface %s present=%v) — decommissioning", unitEnabled, m.iface, ifacePresent)
+		if err := m.iface_Down(ctx); err != nil {
+			log.Printf("awg: decommission kernel residue: %v", err)
+		}
+		return
+	}
+	// kernel backend: drop an orphaned managed endpoint from the active config.
+	if err := m.decommissionSingbox(); err != nil {
+		log.Printf("awg: remove orphaned singbox endpoint: %v", err)
+	}
 }
 
 // SetConfigSync wires the config-sync callback, the post-change apply (reload)
@@ -258,14 +338,8 @@ func (m *Manager) disableSingbox(ctx context.Context) error {
 	if m.cfgSync == nil {
 		return fmt.Errorf("config sync not wired")
 	}
-	changed, err := m.cfgSync.SyncAwgEndpointActive(config.ManagedAwgServerTag, nil)
-	if err != nil {
+	if err := m.decommissionSingbox(); err != nil {
 		return err
-	}
-	if changed && m.applyFn != nil {
-		if err := m.applyFn(); err != nil {
-			return err
-		}
 	}
 	m.mu.Lock()
 	m.enabled, m.phase = false, PhaseIdle

--- a/backend/internal/awg/switch_test.go
+++ b/backend/internal/awg/switch_test.go
@@ -1,0 +1,222 @@
+package awg
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// linkPresentUntil scripts `ip link show dev <iface>` statefully: the link reads
+// as present until a call whose joined argv contains downMarker has happened,
+// then reads as absent. Mirrors a real teardown (down command removes the link).
+func linkPresentUntil(f *fakeRunner, iface, downMarker string) {
+	f.match = func(name string, args []string) (string, bool) {
+		joined := name + " " + strings.Join(args, " ")
+		if joined != "ip link show dev "+iface {
+			return "", false
+		}
+		// Present unless the down command already ran (skip the current call,
+		// which IS the ip-link probe just appended to f.calls).
+		for _, c := range f.calls[:len(f.calls)-1] {
+			if strings.Contains(strings.Join(c, " "), downMarker) {
+				return "", false // absent -> fall through to errs/outputs (empty out)
+			}
+		}
+		return "1: " + iface + ": <POINTOPOINT,UP>", true
+	}
+}
+
+// Unit-managed launch: `systemctl disable --now` takes the link down, so no
+// direct awg-quick/ip-link teardown must run (and boot persistence is cleared).
+func TestIfaceDownUnitManaged(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	linkPresentUntil(f, m.iface, "systemctl disable --now awg-quick@"+m.iface)
+	if err := m.iface_Down(context.Background()); err != nil {
+		t.Fatalf("iface_Down: %v", err)
+	}
+	if f.sawContains("awg-quick down") || f.sawContains("ip link delete") {
+		t.Fatalf("unit stop sufficed; no direct teardown expected: calls=%v", f.calls)
+	}
+}
+
+// Manually-launched iface (awg-quick up outside the unit): the unit stop is a
+// no-op for the link, so iface_Down must fall through to `awg-quick down`.
+func TestIfaceDownManualLaunch(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	linkPresentUntil(f, m.iface, "awg-quick down "+m.iface)
+	if err := m.iface_Down(context.Background()); err != nil {
+		t.Fatalf("iface_Down: %v", err)
+	}
+	if !f.sawContains("awg-quick down " + m.iface) {
+		t.Fatalf("manual launch must be taken down via awg-quick; calls=%v", f.calls)
+	}
+	if f.sawContains("ip link delete") {
+		t.Fatalf("awg-quick down sufficed; no force-delete expected: calls=%v", f.calls)
+	}
+}
+
+// Non-systemd box: systemctl fails outright, but awg-quick down still works —
+// iface_Down must report success (outcome-judged, not exit-code-judged).
+func TestIfaceDownNoSystemd(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	f.errs["systemctl disable --now awg-quick@"+m.iface] = errFake
+	linkPresentUntil(f, m.iface, "awg-quick down "+m.iface)
+	if err := m.iface_Down(context.Background()); err != nil {
+		t.Fatalf("iface_Down without systemd: %v", err)
+	}
+	if !f.sawContains("awg-quick down " + m.iface) {
+		t.Fatalf("expected awg-quick down fallback; calls=%v", f.calls)
+	}
+}
+
+// awg-tools broken/missing while the module keeps the iface alive: the last
+// resort is `ip link delete` plus the RBOX-AWG-* chain teardown (PostDown never
+// ran on this path).
+func TestIfaceDownForceDelete(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	f.errs["awg-quick down "+m.iface] = errFake
+	linkPresentUntil(f, m.iface, "ip link delete dev "+m.iface)
+	if err := m.iface_Down(context.Background()); err != nil {
+		t.Fatalf("iface_Down force path: %v", err)
+	}
+	if !f.sawContains("ip link delete dev " + m.iface) {
+		t.Fatalf("expected ip link delete fallback; calls=%v", f.calls)
+	}
+	for _, chain := range []string{"RBOX-AWG-NAT", "RBOX-AWG-FWD", "RBOX-AWG-IN"} {
+		if !f.sawContains("-F " + chain) {
+			t.Fatalf("expected NAT cleanup of %s; calls=%v", chain, f.calls)
+		}
+	}
+}
+
+// Nothing takes the link down -> iface_Down must fail loudly (a silent success
+// here is exactly the reported bug: kernel keeps running, panel looks clean).
+func TestIfaceDownStillUpFails(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	f.errs["awg-quick down "+m.iface] = errFake
+	linkPresentUntil(f, m.iface, "\x00never") // link never goes away
+	if err := m.iface_Down(context.Background()); err == nil {
+		t.Fatal("want error when the interface survives every teardown step")
+	}
+}
+
+// kernel -> singbox: the switch must decommission the kernel runtime (unit
+// disable at minimum), even though the panel state says "disabled".
+func TestPrepareBackendSwitchKernelToSingbox(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	m.SetBackend("kernel")
+	if err := m.PrepareBackendSwitch(context.Background(), "singbox"); err != nil {
+		t.Fatalf("PrepareBackendSwitch: %v", err)
+	}
+	if !f.sawContains("systemctl disable --now awg-quick@" + m.iface) {
+		t.Fatalf("switch must clear the kernel unit's boot persistence; calls=%v", f.calls)
+	}
+}
+
+// Same-backend "switch" is a no-op: nothing must be torn down.
+func TestPrepareBackendSwitchSameBackendNoop(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	m.SetBackend("singbox")
+	if err := m.PrepareBackendSwitch(context.Background(), "singbox"); err != nil {
+		t.Fatalf("PrepareBackendSwitch: %v", err)
+	}
+	if len(f.calls) != 0 {
+		t.Fatalf("same-backend switch must run nothing; calls=%v", f.calls)
+	}
+}
+
+// singbox -> kernel: the switch must drop the managed endpoint from the active
+// config (idempotent) and reload on a real change.
+func TestPrepareBackendSwitchSingboxToKernel(t *testing.T) {
+	m, fs, applyCount := newSingboxMgr(t)
+	if err := m.PrepareBackendSwitch(context.Background(), "kernel"); err != nil {
+		t.Fatalf("PrepareBackendSwitch: %v", err)
+	}
+	if fs.calls != 1 || fs.lastSpec != nil {
+		t.Fatalf("expected one removal sync (nil spec); calls=%d spec=%#v", fs.calls, fs.lastSpec)
+	}
+	if *applyCount != 1 {
+		t.Fatalf("removal changed the config; apply calls = %d, want 1", *applyCount)
+	}
+}
+
+func TestPrepareBackendSwitchInvalidTarget(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	if err := m.PrepareBackendSwitch(context.Background(), "wireguard"); err == nil {
+		t.Fatal("want error on an unknown backend target")
+	}
+}
+
+// Boot reconcile, singbox backend: a still-enabled kernel unit (residue of a
+// pre-fix switch) must be decommissioned — this is what heals installs already
+// in the reported broken state.
+func TestReconcileResidueSingboxKillsKernelLeftover(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	m.SetBackend("singbox")
+	// RouteBox-rendered conf exists -> the iface name is ours.
+	os.MkdirAll(filepath.Dir(m.confPath), 0700)
+	os.WriteFile(m.confPath, []byte("[Interface]\n"), 0600)
+	f.outputs["systemctl is-enabled awg-quick@"+m.iface] = "enabled\n"
+	linkPresentUntil(f, m.iface, "systemctl disable --now awg-quick@"+m.iface)
+
+	m.ReconcileBackendResidue(context.Background())
+	if !f.sawContains("systemctl disable --now awg-quick@" + m.iface) {
+		t.Fatalf("boot reconcile must decommission the kernel leftover; calls=%v", f.calls)
+	}
+}
+
+// Boot reconcile must NOT touch an iface RouteBox never rendered a conf for —
+// an operator's unrelated awg-quick setup with our default name stays alive.
+func TestReconcileResidueSingboxNoConfNoTouch(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	m.SetBackend("singbox")
+	m.confPath = filepath.Join(t.TempDir(), "absent", "awg-rb0.conf")
+	f.outputs["systemctl is-enabled awg-quick@"+m.iface] = "enabled\n"
+
+	m.ReconcileBackendResidue(context.Background())
+	if f.sawContains("systemctl disable") || f.sawContains("awg-quick down") || f.sawContains("ip link delete") {
+		t.Fatalf("no RouteBox conf -> not our iface -> must not be torn down; calls=%v", f.calls)
+	}
+}
+
+// Boot reconcile, singbox backend with a clean system: probes only, no teardown.
+func TestReconcileResidueSingboxCleanNoop(t *testing.T) {
+	f := newFakeRunner()
+	m := newTestManager(t, f)
+	m.SetBackend("singbox")
+	os.MkdirAll(filepath.Dir(m.confPath), 0700)
+	os.WriteFile(m.confPath, []byte("[Interface]\n"), 0600)
+	f.errs["systemctl is-enabled awg-quick@"+m.iface] = errFake // not-enabled
+	// default fake: `ip link show` returns ("", nil) -> absent
+
+	m.ReconcileBackendResidue(context.Background())
+	if f.sawContains("systemctl disable") || f.sawContains("awg-quick down") || f.sawContains("ip link delete") {
+		t.Fatalf("clean system -> reconcile must be probe-only; calls=%v", f.calls)
+	}
+}
+
+// Boot reconcile, kernel backend: an orphaned managed endpoint in the active
+// config is removed (and the config reloaded).
+func TestReconcileResidueKernelRemovesOrphanEndpoint(t *testing.T) {
+	m, fs, applyCount := newSingboxMgr(t)
+	m.SetBackend("kernel")
+	m.ReconcileBackendResidue(context.Background())
+	if fs.calls != 1 || fs.lastSpec != nil {
+		t.Fatalf("expected one removal sync (nil spec); calls=%d spec=%#v", fs.calls, fs.lastSpec)
+	}
+	if *applyCount != 1 {
+		t.Fatalf("apply calls = %d, want 1", *applyCount)
+	}
+}


### PR DESCRIPTION
## Problem

Switching the AWG backend (`kernel` ↔ `singbox`) only checked `Status().Enabled == false`, `Busy()`, and the draft gate, then flipped the setting. **Nothing ever decommissioned the outgoing backend**, so the kernel runtime could keep working after switching to singbox:

- `Status().Enabled` on the kernel path is derived from the live interface (`awg show`). An **enabled-but-inactive `awg-quick@` unit** (reboot window, failed unit, manual `awg-quick down` outside the panel) passes the guard — and the still-enabled unit resurrects the kernel iface at the next boot, invisible to the panel (Status now routes to singbox) and competing with the singbox endpoint for the UDP listen port.
- A **broken/uninstalled `awg` tool** makes the live probe fail → Status reports disabled while the interface is up → switch goes through, kernel keeps running.
- `iface_Down` was only `systemctl disable --now`: a **manually-launched iface** (`awg-quick up` outside the unit) isn't touched by the unit stop (Disable reported success while the tunnel kept running), and **non-systemd boxes** just failed.
- Installs **already in the split state** (settings say `singbox`, `awg-quick@` still enabled/running) were never healed.
- A **stale persisted `awg.enabled=true`** made the next RouteBox restart rehydrate the *new* backend as silently enabled.

## Changes

- **`iface_Down` covers every launch variant, judged by outcome not exit codes**: `systemctl disable --now` (clears boot persistence) → `awg-quick down` if the link survives (manual launches, non-systemd) → `ip link delete` + explicit `RBOX-AWG-*` chain teardown as a last resort (PostDown never ran on that path). Errors only when the link actually survives all three.
- **`Manager.PrepareBackendSwitch`** decommissions the outgoing backend *before* the setting is persisted: kernel→singbox runs the full teardown above; singbox→kernel drops an orphaned managed endpoint from the active config (reload only on a real change). Wired into the settings handler ahead of `Update`/`Save`, so a failed teardown leaves no split state (409, nothing changed).
- **`Manager.ReconcileBackendResidue`** heals already-broken installs at RouteBox startup: backend=singbox with an enabled unit or live iface → decommission (logged); backend=kernel with an orphan endpoint → removal. Gated on RouteBox's own rendered conf, so an operator's unrelated awg-quick setup with the same iface name is never touched.
- **A switch atomically persists `awg.enabled=false`** alongside the new backend value.

## Tests

- 5 teardown-variant tests for `iface_Down` (unit-managed / manual launch / no systemd / force-delete + NAT cleanup / still-up-fails-loudly), with a stateful fake runner that flips link presence after the effective down command.
- `PrepareBackendSwitch`: kernel→singbox decommissions, singbox→kernel removes the endpoint + reloads, same-backend no-op, invalid target errors.
- `ReconcileBackendResidue`: heals a leftover kernel unit under singbox, probe-only on a clean system, refuses to touch an iface without a RouteBox-rendered conf, removes an orphan endpoint under kernel.
- Handler-level test: full kernel→singbox switch with stale state — unit decommissioned, backend persisted, stale `awg.enabled` reset, live Manager mirrored.

`go vet`, `go build`, full `go test ./backend/...` and `-race` on the awg package are green. Frontend contract (`awg.backend` via `updateSettings`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbdEmWjek5CrABTMXc43H8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbdEmWjek5CrABTMXc43H8)_