### PR TITLE
ci: release pipeline on version tags + CI gate for source

### DIFF
--- a/.github/scripts/extract-changelog.sh
+++ b/.github/scripts/extract-changelog.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Builds the short release notes for one version, mirroring the format of the
+# hand-written releases:
+#
+#   ## RouteBox vX.Y.Z
+#
+#   <the "## [X.Y.Z]" section of CHANGELOG.md>
+#
+#   Full changelog: <link>
+#
+# When CHANGELOG.md has no section for the version (tag cut before the
+# changelog was updated), falls back to the commit subjects since the previous
+# tag so the release is never published with an empty body.
+set -euo pipefail
+
+VERSION="${1:?usage: extract-changelog.sh <version-without-v>}"
+
+# Everything between "## [X.Y.Z]" and the next "## [" heading.
+section=$(awk -v ver="$VERSION" '
+	index($0, "## [" ver "]") == 1 { grab = 1; next }
+	/^## \[/                       { grab = 0 }
+	grab                           { print }
+' CHANGELOG.md)
+
+if [ -z "$(printf '%s' "$section" | tr -d '[:space:]')" ]; then
+	prev=$(git describe --tags --abbrev=0 "v${VERSION}^" 2>/dev/null || echo "")
+	if [ -n "$prev" ]; then
+		range="${prev}..v${VERSION}"
+	else
+		range="v${VERSION}"
+	fi
+	commits=$(git log --no-merges --pretty='- %s' "$range" 2>/dev/null || true)
+	if [ -z "$commits" ]; then
+		commits="- See the linked changelog."
+	fi
+	section="### Changes"$'\n\n'"$commits"
+fi
+
+echo "## RouteBox v${VERSION}"
+echo
+# Trim leading blank lines; trailing ones are harmless in markdown.
+printf '%s\n' "$section" | awk 'NF { found = 1 } found'
+echo
+echo "Full changelog: [CHANGELOG.md](https://github.com/hoaxisr/routebox/blob/source/CHANGELOG.md)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+# CI gate for the development branch: the same checks the release pipeline
+# runs, minus the binary build/publish, so a red tag build is never a surprise.
+name: CI
+
+on:
+  push:
+    branches: [source]
+  pull_request:
+    branches: [source]
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Check, test, build
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run check
+          npm test
+          npm run build
+
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Vet, test, build
+        run: |
+          go vet ./backend/...
+          go test ./backend/...
+          CGO_ENABLED=0 go build ./backend/cmd/routebox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+# Release pipeline: push a version tag (v1.2.3) and this builds the panel
+# (frontend embedded into the Go binary), runs the full test suite as a gate,
+# publishes routebox-linux-{amd64,arm64} + .sha256 sidecars (the exact asset
+# names install.sh and the in-app self-updater download), and fills the release
+# body with the tag's CHANGELOG.md section via .github/scripts/extract-changelog.sh.
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write # create the release + upload assets
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # the changelog fallback needs tags + history (git describe)
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run check
+          npm test
+          npm run build
+
+      # go:embed all:dist compiles the SPA into the binary — the dist dir is
+      # gitignored (only .gitkeep), so populate it from the fresh build.
+      - name: Embed frontend into the Go binary
+        run: |
+          rm -rf backend/internal/embedded/dist
+          mkdir -p backend/internal/embedded/dist
+          cp -r frontend/build/. backend/internal/embedded/dist/
+
+      - name: Backend tests
+        run: |
+          go vet ./backend/...
+          go test ./backend/...
+
+      # CGO_ENABLED=0: all deps are pure Go (modernc.org/sqlite), so the binary
+      # is static and runs on any glibc/musl box. Version is stamped the way
+      # main.go expects (-X main.Version, no leading "v").
+      - name: Build release binaries
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p dist
+          for arch in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="$arch" \
+              go build -trimpath -ldflags "-s -w -X main.Version=${VERSION}" \
+              -o "dist/routebox-linux-${arch}" ./backend/cmd/routebox
+          done
+          cd dist
+          for f in routebox-linux-*; do
+            sha256sum "$f" > "$f.sha256"
+          done
+          ls -la
+
+      - name: Build release notes
+        run: |
+          ./.github/scripts/extract-changelog.sh "${GITHUB_REF_NAME#v}" > release-notes.md
+          echo "----- release body -----"
+          cat release-notes.md
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release-notes.md
+          files: dist/*


### PR DESCRIPTION
## Summary

CI/CD via GitHub Actions: pushing a version tag builds and publishes the release assets with a short changelog; pushes/PRs to `source` run the same checks as a gate.

## Release pipeline (`.github/workflows/release.yml`)

Triggered by a `v*` tag push:

1. Frontend: `npm ci` → `svelte-check` → vitest → SPA build.
2. SPA copied into `backend/internal/embedded/dist` (gitignored; `go:embed all:dist` compiles it into the binary).
3. Backend gate: `go vet` + `go test ./backend/...` — red tests block publishing.
4. Cross-compiles static `routebox-linux-amd64` and `routebox-linux-arm64` (`CGO_ENABLED=0`, all deps are pure Go; version stamped via `-X main.Version` without the leading `v`, as `main.go` expects).
5. `sha256sum`-format `.sha256` sidecars next to each binary.
6. Publishes the GitHub release with the generated notes and assets.

Asset names match exactly what `install.sh` (`routebox-linux-${ARCH}`, amd64 + arm64) and the in-app self-updater (`RouteBoxTarget`, `routebox-linux-amd64`) already download. arm64 — which install.sh supports but manual releases never shipped — now gets published too.

## Short changelog (`.github/scripts/extract-changelog.sh`)

Release body = the tag's `## [X.Y.Z]` section of CHANGELOG.md wrapped in the same format as past hand-written releases (`## RouteBox vX.Y.Z` header + section + "Full changelog" link). Verified against `0.24.1`: the output reproduces the published release body. If the section is missing (tag cut before the changelog commit), it falls back to commit subjects since the previous tag, so a release never publishes with an empty body.

## CI gate (`.github/workflows/ci.yml`)

Same checks minus build/publish on pushes and PRs to `source`.

## Release flow from now on

Update CHANGELOG.md (`## [X.Y.Z]` section), commit the version bump, then `git tag vX.Y.Z && git push origin vX.Y.Z` — Actions does the rest.

All steps were exercised locally: frontend build, embed, both arch builds, version stamp (`routebox version …`), changelog extraction and its fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbdEmWjek5CrABTMXc43H8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbdEmWjek5CrABTMXc43H8)_