### PR TITLE
fix(awg): singbox peers use real handshakes instead of traffic-derived liveness

### DIFF
--- a/backend/cmd/routebox/main.go
+++ b/backend/cmd/routebox/main.go
@@ -420,6 +420,15 @@ func main() {
 			return seen
 		})
 	}
+	// Real per-peer handshake/tx/rx on the singbox backend, straight from the
+	// WireGuard device's own UAPI state (amnezia-box's GET /awg/{tag}/peers) —
+	// SetPeerLiveness above only runs as a fallback when this errors with
+	// errAwgPeerStatsUnsupported (an amnezia-box binary older than that route).
+	if resolvedClashAddr != "" {
+		awgMgr.SetPeerStats(func() (map[string]awg.PeerStat, error) {
+			return awg.FetchAwgPeerStats(resolvedClashAddr, resolvedClashSecret, config.ManagedAwgServerTag)
+		})
+	}
 	// Resolve the AWG backend: explicit setting wins; otherwise default to singbox
 	// (no kernel module required). Kernel is opt-in only — a router/VPS never runs
 	// the kernel-module install path unless the operator explicitly selects it.

--- a/backend/internal/awg/manager.go
+++ b/backend/internal/awg/manager.go
@@ -22,10 +22,12 @@ import (
 
 // PeerSummary is the secret-free API/UI view of a peer.
 //
-// The liveness pair means slightly different things per backend, because the
-// backends expose different things: on kernel it is a real handshake off the
-// interface, on singbox the last minute the peer's tunnel IP moved bytes (see
-// listPeersSingbox). Rx/Tx are interface counters and stay zero on singbox.
+// On kernel, the liveness pair and Rx/Tx come from a real handshake and
+// interface counters (awg show). On singbox they come from the WireGuard
+// device's own UAPI state via peerStatsFn — a real handshake too, just
+// reached over the Clash API instead of a kernel interface — falling back to
+// livenessFn's traffic-derived approximation (see listPeersSingbox) only on
+// an amnezia-box binary that predates that route.
 type PeerSummary struct {
 	Name          string `json:"name"`
 	PublicKey     string `json:"public_key"`
@@ -108,9 +110,23 @@ type Manager struct {
 	// "supported" is the wrong default.
 	kernelSupports3Fn func() bool
 
+	// peerStatsFn is the singbox backend's real handshake/tx/rx signal: the
+	// WireGuard device's own UAPI state via amnezia-box's /awg/{tag}/peers
+	// (see SetPeerStats). Returns ErrAwgPeerStatsUnsupported on a pre-patch
+	// amnezia-box binary (no such route) — listPeersSingbox falls back to
+	// livenessFn in that case, and to "everyone offline" if neither is wired.
+	peerStatsFn func() (map[string]PeerStat, error)
+
+	// lastPeerStatsErr dedupes fetch-error logging for peerStatsFn the same
+	// way traffic.Sampler dedupes its own: ListPeers can be polled every few
+	// seconds, and a persistent failure (secret rotated, amnezia-box down)
+	// must log once, not once per poll. Touched only under mu.
+	lastPeerStatsErr string
+
 	// livenessFn answers "when did this tunnel IP last move bytes", and exists
-	// for the singbox backend only (see SetPeerLiveness). nil = nothing wired,
-	// and every peer reads offline — what the roster did before this existed.
+	// for the singbox backend as a fallback for amnezia-box binaries that
+	// predate peerStatsFn (see SetPeerLiveness). nil = nothing wired, and
+	// every peer reads offline — what the roster did before either existed.
 	livenessFn func(since int64) map[string]int64
 
 	// IPv6-broker wiring (dual-stack NAT-free AWG): ipv6Broker is the operator's
@@ -452,10 +468,20 @@ func (m *Manager) AddPeer(ctx context.Context, rawName string) (PeerSummary, err
 // SetPeerLiveness wires the singbox backend's substitute for a handshake: a
 // lookup of tunnel IP -> the unix second it was last seen moving bytes, over
 // everything at or after `since`. Wired from the traffic store in main; nil in
-// tests and on panels with no monitoring.
+// tests and on panels with no monitoring. Used only as a fallback when
+// peerStatsFn is unset or reports ErrAwgPeerStatsUnsupported.
 func (m *Manager) SetPeerLiveness(fn func(since int64) map[string]int64) {
 	m.mu.Lock()
 	m.livenessFn = fn
+	m.mu.Unlock()
+}
+
+// SetPeerStats wires the singbox backend's real per-peer handshake/tx/rx
+// signal — see peerStatsFn. nil (unset) falls straight to the livenessFn
+// fallback.
+func (m *Manager) SetPeerStats(fn func() (map[string]PeerStat, error)) {
+	m.mu.Lock()
+	m.peerStatsFn = fn
 	m.mu.Unlock()
 }
 
@@ -492,40 +518,64 @@ func (m *Manager) ListPeers(ctx context.Context) []PeerSummary {
 	return out
 }
 
-// listPeersSingbox fills the roster's liveness from recorded traffic instead of
-// from the interface.
+// listPeersSingbox fills the roster's liveness from the WireGuard device's
+// own UAPI state (peerStatsFn) when available, falling back to recorded
+// traffic (livenessFn) only on an amnezia-box binary that predates that
+// route.
 //
-// sing-box serves AWG from a userspace endpoint: there is no awg-rb0, `awg show`
-// has nothing to report, and the kernel path above therefore marked every peer
-// never-handshaked. The roster and the per-user monitor both read that as
-// "offline", permanently, for peers that were connected and working.
+// sing-box serves AWG from a userspace endpoint: there is no awg-rb0 for
+// `awg show` to query, so the kernel path above cannot be reused directly.
+// amnezia-box (hoaxisr/amnezia-box) exposes the same handshake/tx/rx state
+// `wg show`/`awg show` would read off a kernel interface through its Clash
+// API instead (GET /awg/{tag}/peers) — see FetchAwgPeerStats — which is why
+// this can key straight off PublicKey exactly like the kernel path does.
 //
-// The stand-in is the newest per-minute traffic bucket for the peer's tunnel IP
-// — the same rows /api/awg/peers/traffic already reports bytes from. Two honest
-// differences from a real handshake, both inherent to what sing-box exposes:
-// it is a minute coarse (the sampler ticks once a minute), and a peer that is
-// connected but silent drops offline after onlineWindowSec where a kernel peer
-// would keep rekeying. It reports activity, not tunnel state.
-//
-// Rx/Tx stay zero: they mean "cumulative since the interface came up" and there
-// is no interface. The roster hides them on this backend for that reason, and
-// the traffic endpoint answers the question properly, over a chosen window.
+// The livenessFn fallback approximates liveness from the newest per-minute
+// traffic bucket for the peer's tunnel IP instead — coarser (minute
+// resolution) and prone to reading a connected-but-quiet peer as offline
+// after onlineWindowSec, where a real handshake would keep rekeying — used
+// only when peerStatsFn is unset or reports ErrAwgPeerStatsUnsupported.
 func (m *Manager) listPeersSingbox() []PeerSummary {
 	m.mu.Lock()
-	fn := m.livenessFn
+	statsFn, liveFn := m.peerStatsFn, m.livenessFn
+	lastErr := m.lastPeerStatsErr
 	m.mu.Unlock()
 
 	now := time.Now().Unix()
-	var seen map[string]int64
-	if fn != nil {
-		seen = fn(now - lastSeenLookbackSec)
+	var stats map[string]PeerStat
+	if statsFn != nil {
+		var err error
+		stats, err = statsFn()
+		errText := ""
+		if err != nil {
+			errText = err.Error()
+		}
+		if errText != lastErr {
+			if err != nil && !errors.Is(err, ErrAwgPeerStatsUnsupported) {
+				log.Printf("awg: singbox peer stats unavailable, falling back to traffic-based liveness: %v", err)
+			}
+			m.mu.Lock()
+			m.lastPeerStatsErr = errText
+			m.mu.Unlock()
+		}
 	}
+
+	var seen map[string]int64
+	if stats == nil && liveFn != nil {
+		seen = liveFn(now - lastSeenLookbackSec)
+	}
+
 	out := []PeerSummary{}
 	for _, p := range m.store.List() {
-		ts := seen[tunnelIP(p.Address)]
+		var ts, rx, tx int64
+		if stat, ok := stats[p.PublicKey]; ok {
+			ts, rx, tx = stat.LastHandshake, stat.RxBytes, stat.TxBytes
+		} else if stats == nil {
+			ts = seen[tunnelIP(p.Address)]
+		}
 		out = append(out, PeerSummary{
 			Name: p.Name, PublicKey: p.PublicKey, Address: p.Address,
-			LastHandshake: ts, Online: isOnline(ts, now),
+			LastHandshake: ts, Online: isOnline(ts, now), Rx: rx, Tx: tx,
 			ExpiresAt: p.ExpiresAt,
 		})
 	}

--- a/backend/internal/awg/singbox.go
+++ b/backend/internal/awg/singbox.go
@@ -608,7 +608,9 @@ func (m *Manager) disableSingbox(ctx context.Context) error {
 }
 
 // statusSingbox reports a kernel-field-free status: running = we have a server key
-// (enabled) AND the process is alive. Liveness/NAT/module are not applicable.
+// (enabled) AND the process is alive. NAT/module are not applicable; Online/Rx/Tx
+// are aggregated from listPeersSingbox — the same real-handshake-or-fallback data
+// the roster renders, so the strip and the peer list never disagree.
 func (m *Manager) statusSingbox(ctx context.Context) AWGStatus {
 	m.mu.Lock()
 	enabled, lastErr, port, phase := m.enabled, m.lastErr, m.listenPort, m.phase
@@ -617,6 +619,16 @@ func (m *Manager) statusSingbox(ctx context.Context) AWGStatus {
 	m.mu.Unlock()
 	if phase == "" {
 		phase = PhaseIdle
+	}
+	peers := m.listPeersSingbox()
+	online := 0
+	var rx, tx int64
+	for _, p := range peers {
+		if p.Online {
+			online++
+		}
+		rx += p.Rx
+		tx += p.Tx
 	}
 	// ConfigDirty mirrors the kernel Status: enabled AND the saved settings differ
 	// from the running snapshot on any field that needs a re-apply — subnet, port,
@@ -636,7 +648,10 @@ func (m *Manager) statusSingbox(ctx context.Context) AWGStatus {
 		Phase:       phase,
 		ListenPort:  port,
 		PublicHost:  m.publicHost,
-		PeerCount:   len(m.store.List()),
+		PeerCount:   len(peers),
+		Online:      online,
+		Rx:          rx,
+		Tx:          tx,
 		Module:      StateReady, // module not applicable; report ready so UI doesn't warn
 		ConfigDirty: configDirty,
 		IPv6Active:  v6active,

--- a/backend/internal/awg/singbox_peers.go
+++ b/backend/internal/awg/singbox_peers.go
@@ -1,0 +1,76 @@
+package awg
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// awgPeerStatsHTTPClient bounds the call so a hung Clash API socket can't
+// stall a roster fetch indefinitely. This is a loopback call (Clash API is
+// 127.0.0.1-only), so a generous ceiling never bites in practice.
+var awgPeerStatsHTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+// ErrAwgPeerStatsUnsupported means the running amnezia-box binary predates
+// the /awg/{tag}/peers route (hoaxisr/amnezia-box, "expose real per-peer AWG
+// handshake/tx/rx via UAPI") — an expected, steady-state condition on an
+// unpatched binary, not a transient failure. Callers use it to fall back
+// without treating every poll as an error worth logging.
+var ErrAwgPeerStatsUnsupported = errors.New("amnezia-box binary predates the /awg/{tag}/peers route")
+
+// PeerStat is one peer's slice of GET /awg/{tag}/peers — the WireGuard
+// device's own UAPI state (see amnezia-box's transport/awg.Device.IpcGet),
+// not an approximation from traffic or Clash's connection tracker. Exported
+// so main can name it in the closure passed to Manager.SetPeerStats.
+type PeerStat struct {
+	LastHandshake int64
+	TxBytes       int64
+	RxBytes       int64
+}
+
+// FetchAwgPeerStats calls the AWG-endpoint peer-stats extension added to
+// hoaxisr/amnezia-box, returning real per-peer handshake/traffic state keyed
+// by base64 public key — the same identity ListPeers already keys the store
+// by, so no address/tunnel-IP translation is needed the way the traffic-based
+// fallback (SetPeerLiveness) requires.
+func FetchAwgPeerStats(clashAddr, secret, tag string) (map[string]PeerStat, error) {
+	if clashAddr == "" {
+		return nil, fmt.Errorf("no clash api address configured")
+	}
+	req, err := http.NewRequest("GET", "http://"+clashAddr+"/awg/"+tag+"/peers", nil)
+	if err != nil {
+		return nil, err
+	}
+	if secret != "" {
+		req.Header.Set("Authorization", "Bearer "+secret)
+	}
+	resp, err := awgPeerStatsHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrAwgPeerStatsUnsupported
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("clash /awg/%s/peers: status %d", tag, resp.StatusCode)
+	}
+	var data struct {
+		Peers []struct {
+			PublicKey     string `json:"public_key"`
+			LastHandshake int64  `json:"last_handshake"`
+			TxBytes       int64  `json:"tx_bytes"`
+			RxBytes       int64  `json:"rx_bytes"`
+		} `json:"peers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+	out := make(map[string]PeerStat, len(data.Peers))
+	for _, p := range data.Peers {
+		out[p.PublicKey] = PeerStat{LastHandshake: p.LastHandshake, TxBytes: p.TxBytes, RxBytes: p.RxBytes}
+	}
+	return out, nil
+}

--- a/backend/internal/awg/singbox_peers_test.go
+++ b/backend/internal/awg/singbox_peers_test.go
@@ -1,0 +1,128 @@
+package awg
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// peerStatsOf builds an injected peerStatsFn from a fixed public-key-keyed map.
+func peerStatsOf(stats map[string]PeerStat, err error) func() (map[string]PeerStat, error) {
+	return func() (map[string]PeerStat, error) { return stats, err }
+}
+
+func TestListPeersSingbox_PeerStatsTakePriorityOverLiveness(t *testing.T) {
+	m, _, _ := newSingboxMgr(t)
+	sum, err := m.AddPeer(context.Background(), "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	real := time.Now().Unix() - 10
+	stale := time.Now().Unix() - 2*onlineWindowSec
+	m.SetPeerStats(peerStatsOf(map[string]PeerStat{sum.PublicKey: {LastHandshake: real, TxBytes: 100, RxBytes: 200}}, nil))
+	// The traffic fallback would say "stale" — peerStatsFn must win when both are wired.
+	m.SetPeerLiveness(livenessOf(map[string]int64{tunnelIP(sum.Address): stale}))
+
+	peers := m.ListPeers(context.Background())
+	if len(peers) != 1 {
+		t.Fatalf("ListPeers = %+v, want the one peer", peers)
+	}
+	if !peers[0].Online || peers[0].LastHandshake != real {
+		t.Errorf("peer = %+v, want online with the real UAPI handshake %d", peers[0], real)
+	}
+	if peers[0].Tx != 100 || peers[0].Rx != 200 {
+		t.Errorf("peer tx/rx = %d/%d, want 100/200 from the UAPI stats", peers[0].Tx, peers[0].Rx)
+	}
+}
+
+func TestListPeersSingbox_UnsupportedStatsFallsBackToLiveness(t *testing.T) {
+	m, _, _ := newSingboxMgr(t)
+	sum, err := m.AddPeer(context.Background(), "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := time.Now().Unix() - 30
+	m.SetPeerStats(peerStatsOf(nil, ErrAwgPeerStatsUnsupported))
+	m.SetPeerLiveness(livenessOf(map[string]int64{tunnelIP(sum.Address): seen}))
+
+	peers := m.ListPeers(context.Background())
+	if !peers[0].Online || peers[0].LastHandshake != seen {
+		t.Errorf("peer = %+v, want the traffic-liveness fallback to have applied", peers[0])
+	}
+	if peers[0].Tx != 0 || peers[0].Rx != 0 {
+		t.Errorf("peer tx/rx = %d/%d, want 0/0 — the traffic fallback has no per-peer counters", peers[0].Tx, peers[0].Rx)
+	}
+}
+
+func TestListPeersSingbox_PeerNotInStatsReadsOffline(t *testing.T) {
+	m, _, _ := newSingboxMgr(t)
+	if _, err := m.AddPeer(context.Background(), "alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stats source is up and answering, just has no entry for this peer (never
+	// handshaked at all) — must not fall through to the traffic fallback, or a
+	// truly-never-connected peer could read "online" off unrelated traffic.
+	m.SetPeerStats(peerStatsOf(map[string]PeerStat{}, nil))
+	m.SetPeerLiveness(livenessOf(map[string]int64{"10.10.0.99": time.Now().Unix()}))
+
+	peers := m.ListPeers(context.Background())
+	if peers[0].Online || peers[0].LastHandshake != 0 {
+		t.Errorf("peer = %+v, want offline with no last-seen", peers[0])
+	}
+}
+
+func TestFetchAwgPeerStats_ParsesPeersAndAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/awg/awg-server/peers" {
+			t.Errorf("path = %s, want /awg/awg-server/peers", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer s3cret" {
+			t.Errorf("Authorization = %q, want Bearer s3cret", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"peers": []map[string]any{
+				{"public_key": "abc=", "last_handshake": 1700000000, "tx_bytes": 10, "rx_bytes": 20},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	stats, err := FetchAwgPeerStats(srv.Listener.Addr().String(), "s3cret", "awg-server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := PeerStat{LastHandshake: 1700000000, TxBytes: 10, RxBytes: 20}
+	if got := stats["abc="]; got != want {
+		t.Errorf("stats[abc=] = %+v, want %+v", got, want)
+	}
+}
+
+func TestFetchAwgPeerStats_404IsUnsupported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := FetchAwgPeerStats(srv.Listener.Addr().String(), "", "awg-server")
+	if err != ErrAwgPeerStatsUnsupported {
+		t.Errorf("err = %v, want ErrAwgPeerStatsUnsupported", err)
+	}
+}
+
+func TestFetchAwgPeerStats_OtherStatusIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := FetchAwgPeerStats(srv.Listener.Addr().String(), "", "awg-server")
+	if err == nil || err == ErrAwgPeerStatsUnsupported {
+		t.Errorf("err = %v, want a non-nil, non-unsupported error", err)
+	}
+}

--- a/frontend/src/lib/components/awg/PeerRoster.svelte
+++ b/frontend/src/lib/components/awg/PeerRoster.svelte
@@ -13,24 +13,15 @@
 		peers: AwgPeer[];
 		subnet?: string;
 		singbox?: boolean;
-		/** Live source IPs from the connections stream — the freshest liveness signal on singbox. */
-		activeSources?: Set<string>;
 		onChange: () => void | Promise<void>;
 	}
 
-	let { peers, subnet = '', singbox = false, activeSources = new Set(), onChange }: Props = $props();
+	let { peers, subnet = '', singbox = false, onChange }: Props = $props();
 
-	// bare tunnel IP of a peer ("10.30.0.2/32" → "10.30.0.2").
-	const bareIP = (addr: string) => (addr || '').split('/')[0];
-	// A peer is "live" when the server says so — a recent handshake on the kernel
-	// backend, recent recorded traffic on singbox — or, on singbox, when the
-	// connections stream shows an open connection from its tunnel IP. The stream
-	// is the same signal a minute fresher: server-side liveness there comes from
-	// per-minute traffic buckets, so a peer that just connected lights up here
-	// first. Taking either keeps the LED from lying in both directions — it used
-	// to read the stream alone, and a peer connected but momentarily idle has no
-	// open connection and went dark.
-	const isLive = (p: AwgPeer) => p.online || (singbox && activeSources.has(bareIP(p.address)));
+	// A peer is "live" when the server says so — a real handshake either way,
+	// off the kernel interface on that backend and off sing-box's WireGuard
+	// device via its UAPI on the other (see backend/internal/awg/singbox_peers.go).
+	const isLive = (p: AwgPeer) => p.online;
 
 	let newName = $state('');
 	let adding = $state(false);
@@ -235,8 +226,10 @@
 					<div class="peer-meta">
 						<span class="addr">{p.address}</span>
 						<span class="dot-sep">·</span>
+						<span class="seen">{isLive(p) ? $t('awg.online') : lastSeen(p.last_handshake)}</span>
+						<span class="dot-sep">·</span>
+						<span class="xfer">↓ {formatBytes(p.rx)} &nbsp;↑ {formatBytes(p.tx)}</span>
 						{#if singbox}
-							<span class="seen">{isLive(p) ? $t('awg.online') : lastSeen(p.last_handshake)}</span>
 							<span class="dot-sep">·</span>
 							{#if !p.expires_at}
 								<span class="exp">{$t('awg.noExpiry')}</span>
@@ -245,14 +238,9 @@
 							{:else}
 								<span class="exp">{$t('awg.expiredLabel')}</span>
 							{/if}
-						{:else}
-							<span class="seen">{isLive(p) ? $t('awg.online') : lastSeen(p.last_handshake)}</span>
+						{:else if expiryStatus(p.expires_at, nowSec()) === 'active'}
 							<span class="dot-sep">·</span>
-							<span class="xfer">↓ {formatBytes(p.rx)} &nbsp;↑ {formatBytes(p.tx)}</span>
-							{#if expiryStatus(p.expires_at, nowSec()) === 'active'}
-								<span class="dot-sep">·</span>
-								<span class="exp">{$t('awg.expires', { values: { date: unixToDateInput(p.expires_at) } })}</span>
-							{/if}
+							<span class="exp">{$t('awg.expires', { values: { date: unixToDateInput(p.expires_at) } })}</span>
 						{/if}
 					</div>
 				</div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1076,12 +1076,15 @@ export interface AwgPeer {
 	name: string;
 	public_key: string;
 	address: string;
-	// On the kernel backend these are a real handshake; on sing-box, which has
-	// none to expose, they are when the peer's tunnel IP last moved bytes.
+	// A real handshake either way — off the kernel interface on that backend,
+	// off sing-box's WireGuard device via its UAPI on the other (see
+	// backend/internal/awg/singbox_peers.go). Falls back to a traffic-derived
+	// approximation only on a sing-box install running an amnezia-box binary
+	// that predates that route.
 	last_handshake: number; // unix seconds; 0 = never
 	online: boolean;        // within the server's online window
-	rx: number;             // cumulative bytes received (since iface up; 0 on sing-box)
-	tx: number;             // cumulative bytes sent (since iface up; 0 on sing-box)
+	rx: number;             // cumulative bytes received; 0 on the traffic-fallback path
+	tx: number;             // cumulative bytes sent; 0 on the traffic-fallback path
 	expires_at: number;     // unix seconds; 0 = never expires
 }
 

--- a/frontend/src/lib/utils/monitorRows.ts
+++ b/frontend/src/lib/utils/monitorRows.ts
@@ -19,9 +19,9 @@ export type MonitorRow = {
 /**
  * AWG peers as monitor rows. Ids are namespaced so a peer can never collide with
  * a panel user in the row key or the expand map, and liveness is whatever the
- * server computed — a real handshake on the kernel backend, recent recorded
- * traffic on sing-box, which has no handshake to expose. A peer that was never
- * named falls back to its tunnel IP.
+ * server computed — a real handshake either way, off the kernel interface on
+ * that backend and off sing-box's WireGuard device via its UAPI on the other.
+ * A peer that was never named falls back to its tunnel IP.
  */
 export function peersToRows(peers: AwgPeerTraffic[]): MonitorRow[] {
 	return peers.map((p) => ({

--- a/frontend/src/routes/config/awg/+page.svelte
+++ b/frontend/src/routes/config/awg/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { t } from 'svelte-i18n';
 	import { api } from '$lib/api/client';
 	import { notifications, routerMode } from '$lib/stores';
@@ -71,6 +71,13 @@
 	async function refreshPeers() {
 		peers = status?.enabled ? await api.getAwgPeers() : [];
 	}
+
+	async function refreshLive() {
+		await refreshStatus();
+		await refreshPeers();
+	}
+
+	let poll: ReturnType<typeof setInterval> | null = null;
 
 	// Persist the visible form, then refresh status (picks up config_dirty).
 	async function save(): Promise<boolean> {
@@ -162,7 +169,18 @@
 		}
 	}
 
-	onMount(loadAll);
+	onMount(() => {
+		loadAll();
+		// The online dots and traffic figures are only meaningful live — poll while
+		// the tab is open, skipping a tick that would race a save/enable in flight.
+		poll = setInterval(() => {
+			if (!loading && !saving && !enabling) refreshLive();
+		}, 5000);
+	});
+
+	onDestroy(() => {
+		if (poll) clearInterval(poll);
+	});
 </script>
 
 <svelte:head><title>{$t('awg.title')} - RouteBox</title></svelte:head>

--- a/frontend/src/routes/config/awg/+page.svelte
+++ b/frontend/src/routes/config/awg/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { t } from 'svelte-i18n';
-	import { api, createConnectionsStream } from '$lib/api/client';
+	import { api } from '$lib/api/client';
 	import { notifications, routerMode } from '$lib/stores';
 	import { formatBytes } from '$lib/stores/settings';
 	import type { AwgStatus, AwgPeer, AwgServerSettings } from '$lib/types';
@@ -28,28 +28,6 @@
 	// and on the kernel backend only when the host's module + awg-quick/tools have
 	// both confirmed awg3 capability (status.kernel_awg3_available).
 	const awg3Available = $derived(isSingbox || !!status?.kernel_awg3_available);
-
-	// Instant "traffic flowing" overlay for singbox peers. The server already
-	// reports liveness on this backend, but from per-minute traffic buckets, so a
-	// peer that just connected takes up to a minute to light up. The Clash
-	// connections stream shows the same thing immediately. Set of active source
-	// IPs, refreshed from the stream while a singbox server is enabled.
-	let activeSources = $state<Set<string>>(new Set());
-	const streamOn = $derived(isSingbox && !!status?.enabled);
-	$effect(() => {
-		if (!streamOn) {
-			activeSources = new Set();
-			return;
-		}
-		const handle = createConnectionsStream((data) => {
-			const next = new Set<string>();
-			for (const c of data.connections ?? []) {
-				if (c.metadata?.sourceIP) next.add(c.metadata.sourceIP);
-			}
-			activeSources = next;
-		});
-		return () => handle.close();
-	});
 
 	async function changeBackend(b: 'kernel' | 'singbox') {
 		try {
@@ -232,17 +210,15 @@
 				<span class="m-key">{$t('awg.listenPort')}</span>
 			</div>
 
-			{#if !isSingbox}
-				<div class="strip-metric">
-					<span class="m-val">{status.online} / {status.peer_count}</span>
-					<span class="m-key">{$t('awg.connected')}</span>
-				</div>
+			<div class="strip-metric">
+				<span class="m-val">{status.online} / {status.peer_count}</span>
+				<span class="m-key">{$t('awg.connected')}</span>
+			</div>
 
-				<div class="strip-metric">
-					<span class="m-val mono">↓ {formatBytes(status.rx)} &nbsp;↑ {formatBytes(status.tx)}</span>
-					<span class="m-key">{$t('awg.traffic')}</span>
-				</div>
-			{/if}
+			<div class="strip-metric">
+				<span class="m-val mono">↓ {formatBytes(status.rx)} &nbsp;↑ {formatBytes(status.tx)}</span>
+				<span class="m-key">{$t('awg.traffic')}</span>
+			</div>
 
 				{#if status.public_host}
 				<div class="strip-metric">
@@ -297,7 +273,7 @@
 			</div>
 			<div class="clients-body">
 				{#if status.enabled}
-					<PeerRoster {peers} {activeSources} subnet={form.subnet} singbox={isSingbox} onChange={async () => { await refreshStatus(); await refreshPeers(); }} />
+					<PeerRoster {peers} subnet={form.subnet} singbox={isSingbox} onChange={async () => { await refreshStatus(); await refreshPeers(); }} />
 				{:else}
 					<div class="locked-note">{$t('awg.shareLocked')}</div>
 				{/if}
@@ -457,7 +433,7 @@
 					<p class="step-desc">{$t('awg.stepShareDesc')}</p>
 
 					{#if status.enabled}
-						<PeerRoster {peers} {activeSources} subnet={form.subnet} singbox={isSingbox} onChange={async () => { await refreshStatus(); await refreshPeers(); }} />
+						<PeerRoster {peers} subnet={form.subnet} singbox={isSingbox} onChange={async () => { await refreshStatus(); await refreshPeers(); }} />
 					{:else}
 						<div class="locked-note">{$t('awg.shareLocked')}</div>
 					{/if}


### PR DESCRIPTION
## Summary
- sing-box serves AWG from a userspace endpoint: there is no `awg-rb0` for `awg show` to query, and its traffic never surfaces through the Clash API connection tracker either (endpoint routing bypasses `trafficcontrol`'s flow tracking) — so a connected singbox-backend peer could read "never connected" indefinitely. The previous fix (`24522ef`, per-minute traffic bucket for the peer's tunnel IP) shared the same underlying blind spot and could still miss a peer that hadn't yet triggered a tracked flow.
- Depends on [hoaxisr/amnezia-box#6](https://github.com/hoaxisr/amnezia-box/pull/6), which exposes the WireGuard device's own UAPI state through the Clash API (`GET /awg/{tag}/peers`) — a real handshake plus tx/rx bytes, keyed by public key exactly like the kernel path already is.
- `ListPeers`' singbox branch now tries that route first (`Manager.SetPeerStats`/`FetchAwgPeerStats`), falling back to the existing traffic-derived signal (`SetPeerLiveness`) only when the running amnezia-box binary predates the route (`ErrAwgPeerStatsUnsupported` — e.g. a panel updated ahead of its pinned amnezia-box binary).
- Bonus: `Rx`/`Tx` are now populated on the singbox backend too when the new route is available (previously always zero there).

## Test plan
- [x] `go test ./backend/internal/awg/...` — all pass, including new coverage for peer-stats priority over the fallback, the unsupported-route fallback path, a peer absent from stats reading offline (not silently matching unrelated traffic), and `FetchAwgPeerStats`' parsing/auth/404-handling
- [x] `go build ./...`, `go vet ./backend/...` — clean
- [x] Built a full image with a patched amnezia-box (hoaxisr/amnezia-box#6) and deployed it to a live VPS with a real connected AWG client; confirmed in the panel that a peer previously stuck on "never connected" (gray) now shows "online" (green) with a live handshake age